### PR TITLE
Support .NET Core 

### DIFF
--- a/src/TestApp/ColorWipe.cs
+++ b/src/TestApp/ColorWipe.cs
@@ -22,7 +22,7 @@ namespace TestApp
 
 			//Set brightness to maximum (255)
 			//Use Unknown as strip type. Then the type will be set in the native assembly.
-			settings.Channels[0] = new Channel(ledCount, 18, 255, false, StripType.WS2812_STRIP);
+			settings.Channel_1 = new Channel(ledCount, 18, 255, false, StripType.WS2812_STRIP);
 
 			using (var controller = new WS281x(settings))
 			{
@@ -37,7 +37,7 @@ namespace TestApp
 
 		private static void Wipe(WS281x controller, Color color)
 		{
-			for (int i = 0; i <= controller.Settings.Channels[0].LEDs.Count - 1; i++)
+			for (int i = 0; i <= controller.Settings.Channel_1.LEDs.Count - 1; i++)
 			{
 				controller.SetLEDColor(0, i, color);
 				controller.Render();

--- a/src/TestApp/RainbowColorAnimation.cs
+++ b/src/TestApp/RainbowColorAnimation.cs
@@ -24,7 +24,7 @@ namespace TestApp
 
 			//Set brightness to maximum (255)
 			//Use Unknown as strip type. Then the type will be set in the native assembly.
-			settings.Channels[0] = new Channel(ledCount, 18, 255, false, StripType.WS2812_STRIP);
+			settings.Channel_1 = new Channel(ledCount, 18, 255, false, StripType.WS2812_STRIP);
 
 			using (var controller = new WS281x(settings))
 			{
@@ -32,7 +32,7 @@ namespace TestApp
 				while (!request.IsAbortRequested)
 				{
 				
-					for (int i = 0; i <= controller.Settings.Channels[0].LEDCount - 1; i++)
+					for (int i = 0; i <= controller.Settings.Channel_1.LEDCount - 1; i++)
 					{
 						var colorIndex = (i + colorOffset) % colors.Count;
 						controller.SetLEDColor(0, i, colors[colorIndex]);

--- a/src/rpi-ws281x-dotnet.sln
+++ b/src/rpi-ws281x-dotnet.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.757
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "rpi-ws281x-dotnet", "rpi_ws281x\rpi-ws281x-dotnet.csproj", "{5432FD49-28E2-40CC-AAE8-E340503981ED}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5432FD49-28E2-40CC-AAE8-E340503981ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5432FD49-28E2-40CC-AAE8-E340503981ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5432FD49-28E2-40CC-AAE8-E340503981ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5432FD49-28E2-40CC-AAE8-E340503981ED}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {05598D32-E9AC-47E9-8CC6-D5EED433D349}
+	EndGlobalSection
+EndGlobal

--- a/src/rpi_ws281x/Channel.cs
+++ b/src/rpi_ws281x/Channel.cs
@@ -1,18 +1,37 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
-namespace WS281x
+namespace rpi_ws281x
 {
 	/// <summary>
 	/// Represents the channel which holds the LEDs
 	/// </summary>
 	public class Channel
 	{
-		
-		/// <summary>
-		/// Returns the GPIO pin which is connected to the LED strip
-		/// </summary>
-		public int GPIOPin { get; private set; }
+        public Channel() : this(0, 0) { }
+
+        public Channel(int ledCount, int gpioPin) : this(ledCount, gpioPin, 255, false, StripType.Unknown) { }
+
+        public Channel(int ledCount, int gpioPin, byte brightness, bool invert, StripType stripType)
+        {
+            GPIOPin = gpioPin;
+            Invert = invert;
+            Brightness = brightness;
+            StripType = stripType;
+
+            var ledList = new List<LED>();
+            for (int i = 0; i <= ledCount - 1; i++)
+            {
+                ledList.Add(new LED(i));
+            }
+
+            LEDs = new ReadOnlyCollection<LED>(ledList);
+        }
+
+        /// <summary>
+        /// Returns the GPIO pin which is connected to the LED strip
+        /// </summary>
+        public int GPIOPin { get; private set; }
 
 		/// <summary>
 		/// Returns a value which indicates if the signal needs to be inverted.
@@ -32,32 +51,11 @@ namespace WS281x
 		/// </summary>
 		public StripType StripType { get; private set; }
 
-		/// <summary>
-		/// Returns all LEDs on this channel
-		/// </summary>
-		public List<LED> Leds { get; private set; }
+        /// <summary>
+        /// Returns all LEDs on this channel
+        /// </summary>
+        public ReadOnlyCollection<LED> LEDs { get; private set; }
 
-		public int LEDCount { get => Leds.Count; }
-		
-		//public Channel() : this(0, 0) { }
-		
-		public Channel(int ledCount, int gpioPin) : this(ledCount, gpioPin, 255, false, StripType.Unknown)	{ }
-
-		public Channel(int ledCount, int gpioPin, byte brightness, bool invert, StripType stripType)
-		{
-			GPIOPin = gpioPin;
-			Invert = invert;
-			Brightness = brightness;
-			StripType = stripType;
-
-			Leds = new List<LED>();
-			for(int i= 0; i< ledCount; i++)
-			{
-				Leds.Add(new LED(i));
-			}
-
-			//LEDs = new ReadOnlyCollection<LED>(ledList);
-		}
-
-	}
+        public int LEDCount { get => LEDs.Count; }
+    }
 }

--- a/src/rpi_ws281x/Channel.cs
+++ b/src/rpi_ws281x/Channel.cs
@@ -1,32 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
-namespace rpi_ws281x
+namespace WS281x
 {
 	/// <summary>
 	/// Represents the channel which holds the LEDs
 	/// </summary>
 	public class Channel
 	{
-		public Channel() : this(0, 0) { }
-		
-		public Channel(int ledCount, int gpioPin) : this(ledCount, gpioPin, 255, false, rpi_ws281x.StripType.Unknown)	{ }
-
-		public Channel(int ledCount, int gpioPin, byte  brightness, bool invert, StripType stripType)
-		{
-			GPIOPin = gpioPin;
-			Invert = invert;
-			Brightness = brightness;
-			StripType = stripType;
-
-			var ledList = new List<LED>();
-			for(int i= 0; i<= ledCount-1; i++)
-			{
-				ledList.Add(new LED(i));
-			}
-
-			LEDs = new ReadOnlyCollection<LED>(ledList);
-		}
 		
 		/// <summary>
 		/// Returns the GPIO pin which is connected to the LED strip
@@ -41,7 +22,7 @@ namespace rpi_ws281x
 
 		/// <summary>
 		/// Gets or sets the brightness of the LEDs
-		/// 0 = darkes, 255 = brightest
+		/// 0 = darkest, 255 = brightest
 		/// </summary>
 		public byte Brightness { get; set; }
 
@@ -54,9 +35,29 @@ namespace rpi_ws281x
 		/// <summary>
 		/// Returns all LEDs on this channel
 		/// </summary>
-		public ReadOnlyCollection<LED> LEDs { get; private set; }
+		public List<LED> Leds { get; private set; }
 
-		public int LEDCount { get => LEDs.Count; }
+		public int LEDCount { get => Leds.Count; }
 		
+		//public Channel() : this(0, 0) { }
+		
+		public Channel(int ledCount, int gpioPin) : this(ledCount, gpioPin, 255, false, StripType.Unknown)	{ }
+
+		public Channel(int ledCount, int gpioPin, byte brightness, bool invert, StripType stripType)
+		{
+			GPIOPin = gpioPin;
+			Invert = invert;
+			Brightness = brightness;
+			StripType = stripType;
+
+			Leds = new List<LED>();
+			for(int i= 0; i< ledCount; i++)
+			{
+				Leds.Add(new LED(i));
+			}
+
+			//LEDs = new ReadOnlyCollection<LED>(ledList);
+		}
+
 	}
 }

--- a/src/rpi_ws281x/LED.cs
+++ b/src/rpi_ws281x/LED.cs
@@ -1,6 +1,6 @@
 ﻿using System.Drawing;
 
-namespace rpi_ws281x
+namespace WS281x
 {
 	/// <summary>
 	/// Represents a LED which can be controlled by the WS281x controller

--- a/src/rpi_ws281x/LED.cs
+++ b/src/rpi_ws281x/LED.cs
@@ -1,6 +1,6 @@
 ﻿using System.Drawing;
 
-namespace WS281x
+namespace rpi_ws281x
 {
 	/// <summary>
 	/// Represents a LED which can be controlled by the WS281x controller

--- a/src/rpi_ws281x/Native/PInvoke.cs
+++ b/src/rpi_ws281x/Native/PInvoke.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Native
@@ -7,17 +8,21 @@ namespace Native
 	{
 		public const int RPI_PWM_CHANNELS = 2;
 
+		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
-		public static extern ws2811_return_t ws2811_init(ref ws2811_t ws2811);
+		public static extern ws2811_return_t ws2811_init(IntPtr ws2811);
 		
+		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
-		public static extern ws2811_return_t ws2811_render(ref ws2811_t ws2811);
+		public static extern ws2811_return_t ws2811_render(IntPtr ws2811);
 
+		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
-		public static extern ws2811_return_t ws2811_wait(ref ws2811_t ws2811);
+		public static extern ws2811_return_t ws2811_wait(IntPtr ws2811);
 		
+		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
-		public static extern void ws2811_fini(ref ws2811_t ws2811);
+		public static extern void ws2811_fini(IntPtr ws2811);
 
 		[DllImport("ws2811.so")]
 		public static extern IntPtr ws2811_get_return_t_str(int state);

--- a/src/rpi_ws281x/Native/PInvoke.cs
+++ b/src/rpi_ws281x/Native/PInvoke.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace WS281x.Native
+namespace rpi_ws281x.Native
 {
 	internal class PInvoke
 	{

--- a/src/rpi_ws281x/Native/PInvoke.cs
+++ b/src/rpi_ws281x/Native/PInvoke.cs
@@ -2,16 +2,14 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace Native
+namespace WS281x.Native
 {
 	internal class PInvoke
 	{
-		public const int RPI_PWM_CHANNELS = 2;
-
 		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
 		public static extern ws2811_return_t ws2811_init(IntPtr ws2811);
-		
+
 		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
 		public static extern ws2811_return_t ws2811_render(IntPtr ws2811);
@@ -19,11 +17,12 @@ namespace Native
 		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
 		public static extern ws2811_return_t ws2811_wait(IntPtr ws2811);
-		
+
 		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
 		public static extern void ws2811_fini(IntPtr ws2811);
 
+		[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 		[DllImport("ws2811.so")]
 		public static extern IntPtr ws2811_get_return_t_str(int state);
 	}

--- a/src/rpi_ws281x/Native/ws2811_channel_t.cs
+++ b/src/rpi_ws281x/Native/ws2811_channel_t.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Native
+namespace WS281x.Native
 {
 	[StructLayout(LayoutKind.Sequential)]
+	[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 	internal struct ws2811_channel_t
 	{
 		public int gpionum;

--- a/src/rpi_ws281x/Native/ws2811_channel_t.cs
+++ b/src/rpi_ws281x/Native/ws2811_channel_t.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace WS281x.Native
+namespace rpi_ws281x.Native
 {
 	[StructLayout(LayoutKind.Sequential)]
 	[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]

--- a/src/rpi_ws281x/Native/ws2811_return_t.cs
+++ b/src/rpi_ws281x/Native/ws2811_return_t.cs
@@ -1,5 +1,8 @@
-namespace Native
+using System.Diagnostics.CodeAnalysis;
+
+namespace WS281x.Native
 {
+    [SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 	internal enum ws2811_return_t
 	{
 		WS2811_SUCCESS = 0,

--- a/src/rpi_ws281x/Native/ws2811_return_t.cs
+++ b/src/rpi_ws281x/Native/ws2811_return_t.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace WS281x.Native
+namespace rpi_ws281x.Native
 {
     [SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 	internal enum ws2811_return_t

--- a/src/rpi_ws281x/Native/ws2811_t.cs
+++ b/src/rpi_ws281x/Native/ws2811_t.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Native
 {
+	[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 	[StructLayout(LayoutKind.Sequential)]
 	internal struct ws2811_t
 	{
@@ -11,7 +12,9 @@ namespace Native
 		public IntPtr rpi_hw;
 		public uint freq;
 		public int dmanum;
-		[MarshalAs(UnmanagedType.ByValArray, SizeConst = PInvoke.RPI_PWM_CHANNELS)]
-		public ws2811_channel_t[] channel;
+		/* [MarshalAs(UnmanagedType.ByValArray, SizeConst = PInvoke.RPI_PWM_CHANNELS)]
+		public ws2811_channel_t[] channel; */
+		public ws2811_channel_t channel_1;
+		public ws2811_channel_t channel_2;
 	}
 }

--- a/src/rpi_ws281x/Native/ws2811_t.cs
+++ b/src/rpi_ws281x/Native/ws2811_t.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace WS281x.Native
+namespace rpi_ws281x.Native
 {
 	[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 	[StructLayout(LayoutKind.Sequential)]

--- a/src/rpi_ws281x/Native/ws2811_t.cs
+++ b/src/rpi_ws281x/Native/ws2811_t.cs
@@ -1,19 +1,18 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace Native
+namespace WS281x.Native
 {
 	[SuppressMessage("IDE1006", "IDE1006", Justification = "Native methods have different naming conventions.")]
 	[StructLayout(LayoutKind.Sequential)]
-	internal struct ws2811_t
+	internal class ws2811_t
 	{
 		public long render_wait_time;
 		public IntPtr device;
 		public IntPtr rpi_hw;
 		public uint freq;
 		public int dmanum;
-		/* [MarshalAs(UnmanagedType.ByValArray, SizeConst = PInvoke.RPI_PWM_CHANNELS)]
-		public ws2811_channel_t[] channel; */
 		public ws2811_channel_t channel_1;
 		public ws2811_channel_t channel_2;
 	}

--- a/src/rpi_ws281x/Settings.cs
+++ b/src/rpi_ws281x/Settings.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using WS281x.Native;
+using rpi_ws281x.Native;
 
-namespace WS281x
+namespace rpi_ws281x
 {
 	/// <summary>
 	/// Settings which are required to initialize the WS281x controller
@@ -11,30 +11,63 @@ namespace WS281x
 	{
 
         /// <summary>
-        /// Settings to initialize the WS281x controller
+        /// Settings to initialize the WS281x controller with one channel
         /// </summary>
         /// <param name="frequency">Set frequency in Hz</param>
         /// <param name="dmaChannel">Set DMA channel to use</param>
-        public Settings(Channel channel, uint frequency = 800000, int dmaChannel = 10)
-		{
-            Channel = channel;
-			Frequency = frequency;
-			DMAChannel = dmaChannel;
-		}
+        public Settings(Channel channel, uint frequency = 800000, int dmaChannel = 10) : this (channel, null, frequency, dmaChannel) { }
 
-		/// <summary>
-		/// Returns the used frequency in Hz
+        /// <summary>
+        /// Settings to initialize the WS281x controller with up to two channels
+        /// </summary>
+        /// <param name="frequency">Set frequency in Hz</param>
+        /// <param name="dmaChannel">Set DMA channel to use</param>
+        public Settings(Channel channel1, Channel channel2, uint frequency = 800000, int dmaChannel = 10)
+        {
+            Channel_1 = channel1;
+            if (channel2 == null)
+                ChannelCount = 1;
+            else {
+                Channel_2 = channel2;
+                ChannelCount = 2;
+            }
+            Frequency = frequency;
+            DMAChannel = dmaChannel;
+        }
+
+        /// <summary>
+		/// Returns default settings.
+		/// Use a frequency of 800000 Hz and DMA channel 10
 		/// </summary>
-		public uint Frequency { get; private set; }
+		/// <returns></returns>
+		public static Settings CreateDefaultSettings()
+        {
+            return new Settings(null, 800000, 10);
+        }
+
+        /// <summary>
+        /// Returns the used frequency in Hz
+        /// </summary>
+        public uint Frequency { get; private set; }
 
 		/// <summary>
 		/// Returns the DMA channel
 		/// </summary>
 		public int DMAChannel { get; private set; }
 
+        /// <summary>
+        /// Returns the number of channels being used
+        /// </summary>
+        public int ChannelCount { get; private set; }
+
 		/// <summary>
-		/// Returns the channels which holds the LEDs
+		/// Returns Channel 1
 		/// </summary>
-		public Channel Channel { get; set; }
-	}
+		public Channel Channel_1 { get; set; }
+
+        /// <summary>
+		/// Returns Channel 1
+		/// </summary>
+		public Channel Channel_2 { get; set; }
+    }
 }

--- a/src/rpi_ws281x/Settings.cs
+++ b/src/rpi_ws281x/Settings.cs
@@ -1,35 +1,25 @@
-﻿using Native;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using WS281x.Native;
 
-namespace rpi_ws281x
+namespace WS281x
 {
 	/// <summary>
 	/// Settings which are required to initialize the WS281x controller
 	/// </summary>
 	public class Settings
 	{
-	
-		/// <summary>
-		/// Settings to initialize the WS281x controller
-		/// </summary>
-		/// <param name="frequency">Set frequency in Hz</param>
-		/// <param name="dmaChannel">Set DMA channel to use</param>
-		public Settings(uint frequency, int dmaChannel)
+
+        /// <summary>
+        /// Settings to initialize the WS281x controller
+        /// </summary>
+        /// <param name="frequency">Set frequency in Hz</param>
+        /// <param name="dmaChannel">Set DMA channel to use</param>
+        public Settings(Channel channel, uint frequency = 800000, int dmaChannel = 10)
 		{
+            Channel = channel;
 			Frequency = frequency;
 			DMAChannel = dmaChannel;
-			Channels = new Channel[PInvoke.RPI_PWM_CHANNELS];				
-		}
-
-		/// <summary>
-		/// Returns default settings.
-		/// Use a frequency of 800000 Hz and DMA channel 10
-		/// </summary>
-		/// <returns></returns>
-		public static Settings CreateDefaultSettings()
-		{
-			return new Settings(800000, 10);
 		}
 
 		/// <summary>
@@ -45,6 +35,6 @@ namespace rpi_ws281x
 		/// <summary>
 		/// Returns the channels which holds the LEDs
 		/// </summary>
-		public Channel[] Channels { get; private set; }
+		public Channel Channel { get; set; }
 	}
 }

--- a/src/rpi_ws281x/StripType.cs
+++ b/src/rpi_ws281x/StripType.cs
@@ -2,17 +2,19 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace rpi_ws281x
+namespace WS281x
 {
 	/// <summary>
 	/// The type of the LED strip defines the ordering of the colors (e. g. RGB, GRB, ...).
 	/// Maybe the RGBValue property of the LED class needs to be changed if there are other strip types.
 	/// </summary>
-    public enum StripType
-    {
+	public enum StripType
+	{
+		/// <summary>
+		/// Unknown / unset.
+		/// </summary>
 		Unknown = 0,
-		WS2812_STRIP = 0x00081000,
-		
+
 		/// <summary>
 		/// SK6812_STRIP_RGBW
 		/// </summary>

--- a/src/rpi_ws281x/StripType.cs
+++ b/src/rpi_ws281x/StripType.cs
@@ -11,6 +11,66 @@ namespace rpi_ws281x
     public enum StripType
     {
 		Unknown = 0,
-		WS2812_STRIP = 0x00081000
+		WS2812_STRIP = 0x00081000,
+		
+		/// <summary>
+		/// SK6812_STRIP_RGBW
+		/// </summary>
+		SK6812_STRIP_RGBW = 0x18100800,
+
+		/// <summary>
+		/// SK6812_STRIP_RBGW
+		/// </summary>
+		SK6812_STRIP_RBGW = 0x18100008,
+
+		/// <summary>
+		/// SK6812_STRIP_GRBW
+		/// </summary>
+		SK6812_STRIP_GRBW = 0x18081000,
+
+		/// <summary>
+		/// SK6812_STRIP_GBRW
+		/// </summary>
+		SK6812_STRIP_GBRW = 0x18080010,
+
+		/// <summary>
+		/// SK6812_STRIP_BRGW
+		/// </summary>
+		SK6812_STRIP_BRGW = 0x18001008,
+
+		/// <summary>
+		/// SK6812_STRIP_BGRW
+		/// </summary>
+		SK6812_STRIP_BGRW = 0x18000810,
+
+		/// <summary>
+		/// WS2811_STRIP_RGB
+		/// </summary>
+		WS2811_STRIP_RGB = 0x00100800,
+
+		/// <summary>
+		/// WS2811_STRIP_RBG
+		/// </summary>
+		WS2811_STRIP_RBG = 0x00100008,
+
+		/// <summary>
+		/// WS2811_STRIP_GRB
+		/// </summary>
+		WS2811_STRIP_GRB = 0x00081000,
+
+		/// <summary>
+		/// WS2811_STRIP_GBR
+		/// </summary>
+		WS2811_STRIP_GBR = 0x00080010,
+
+		/// <summary>
+		/// WS2811_STRIP_BRG
+		/// </summary>
+		WS2811_STRIP_BRG = 0x00001008,
+
+		/// <summary>
+		/// WS2811_STRIP_BGR
+		/// </summary>
+		WS2811_STRIP_BGR = 0x00000810,
 	}
 }

--- a/src/rpi_ws281x/StripType.cs
+++ b/src/rpi_ws281x/StripType.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace WS281x
+namespace rpi_ws281x
 {
 	/// <summary>
 	/// The type of the LED strip defines the ordering of the colors (e. g. RGB, GRB, ...).
@@ -74,5 +74,7 @@ namespace WS281x
 		/// WS2811_STRIP_BGR
 		/// </summary>
 		WS2811_STRIP_BGR = 0x00000810,
-	}
+
+        WS2812_STRIP = 0x00081000
+    }
 }

--- a/src/rpi_ws281x/rpi-ws281x-dotnet.csproj
+++ b/src/rpi_ws281x/rpi-ws281x-dotnet.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>rpi_ws281x_dotnet</RootNamespace>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/rpi_ws281x/rpi-ws281x-dotnet.csproj
+++ b/src/rpi_ws281x/rpi-ws281x-dotnet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>rpi_ws281x_dotnet</RootNamespace>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #2 

Adds support for .NET Core while maintaining support for mono. Tested on dotnet-2.2, dotnet-3, and mono 5.18.0.240 (latest on raspbian). Multichannel support should still work, though personally unable to test it. 

In order for this fix to work, while still allowing for multichannel support, Settings.Channels[] changed to Settings.Channel_1 and Settings.Channel_2 where channelIndex=0 maps to Channel_1 and channelIndex=1 maps to Channel_2. As such, this changes the usage a little bit. I've created a gist [here](https://gist.github.com/Changer098/41f6bceddee56e85a090fd2e94d1a844) with a demo app showing the change. The TestApp solution is also updated to include this change.